### PR TITLE
Update import of GLOBAL_FUNCTIONS

### DIFF
--- a/ray_processing/process.py
+++ b/ray_processing/process.py
@@ -10,7 +10,7 @@ import json
 
 from baselines.core import process_single_file
 from baselines.core.file_utils import read_jsonl, write_jsonl, delete_file, is_exists
-from ray_processing import GLOBAL_FUNCTIONS
+from baselines.core.constants import GLOBAL_FUNCTIONS
 from ray_processing.utils import generate_untokenized_dataset_json, get_source_ref, get_source_ref_by_key
 
 


### PR DESCRIPTION
In the `process.py` file it looks like it's trying to import `GLOBAL_FUNCTIONS` from `ray_process` but it doesn't seem to be defined there, rather it's defined in `baselines.core.constants`. I was running into import issues when trying to call process.