### PR TITLE
Update README.md -- naive-both -> old-both

### DIFF
--- a/dedup/bff/README.md
+++ b/dedup/bff/README.md
@@ -28,7 +28,7 @@ cargo run --release bff \
    --min-ngram-size 13 \
    --max-ngram-size 13 \
    --filtering-threshold 0.8 \
-   --remove-type naive-both \
+   --remove-type old-both \
    --annotate 
 ```
 


### PR DESCRIPTION
hotfix to the bff readme so as to not suggest users do a buggy dedup method. 

I'll go through and clean the actual rust code here at some later juncture!